### PR TITLE
add monitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
             <version>4.18.0</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>net.bull.javamelody</groupId>
+            <artifactId>javamelody-spring-boot-starter</artifactId>
+            <version>2.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This pull request introduces a new dependency to the `pom.xml` file to enhance application monitoring capabilities.

Dependency addition:

* Added the `javamelody-spring-boot-starter` dependency (version 2.4.0) to enable JavaMelody monitoring for the Spring Boot application.