### PR TITLE
Chatgpt spell check

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ This project includes unit and integration tests to ensure reliability:
 - TodoNotFoundTest — Ensures correct exception for missing todos.
 - TodoCouldNotBeCreatedTest — Ensures correct exception for creation failures.
 - TodoControllerTest — Integration tests for API endpoints and database interactions.
+
+##  🤖 ChatGPT Spellcheck Integration
+
+This project integrates with the OpenAI ChatGPT API to check the spelling of todo items.
+
+### Usage
+
+- The `ChatGptService` sends todo descriptions to the ChatGPT API for spellchecking.
+- If the API call fails, a `ChatGptSpellingRequestException` is thrown.
+- If the spellcheck response is null, a `ChatGptSpellcheckIsNull` exception is thrown.

--- a/src/main/java/com/ecosystem/todojava/dto/ChatGptCheckTodoSpellingRequest.java
+++ b/src/main/java/com/ecosystem/todojava/dto/ChatGptCheckTodoSpellingRequest.java
@@ -1,0 +1,8 @@
+package com.ecosystem.todojava.dto;
+
+public record ChatGptCheckTodoSpellingRequest(String model, String input) {
+    public ChatGptCheckTodoSpellingRequest(String model, String input) {
+        this.model = model;
+        this.input = "Check spelling from for the TODO sentence. You only return the corrected sentence nothing else if the sentence is all ready spelt correct then just give me back the sentence without any changes. Don't add any unnecessary words or anything else just correct the sentence. Not return the TODO: this is just for your information, when the sentence begins. TODO: " + input;
+    }
+}

--- a/src/main/java/com/ecosystem/todojava/dto/ChatGptResponse.java
+++ b/src/main/java/com/ecosystem/todojava/dto/ChatGptResponse.java
@@ -1,0 +1,43 @@
+package com.ecosystem.todojava.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ChatGptResponse {
+    @Override
+    public String toString() {
+        return "ChatGptResponse{" +
+                "output=" + output +
+                '}';
+    }
+
+    private List<Output> output;
+
+    @Setter
+    @Getter
+    public static class Output {
+        private List<Content> content;
+
+        @Setter
+        @Getter
+        public static class Content {
+            private String type;
+            private String text;
+
+        }
+    }
+
+    public String getFirstOutputText() {
+        if (output != null && !output.isEmpty()) {
+            Output firstOutput = output.getFirst();
+            if (firstOutput.getContent() != null && !firstOutput.getContent().isEmpty()) {
+                return firstOutput.getContent().getFirst().getText();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ecosystem/todojava/exception/ChatGptSpellcheckIsNull.java
+++ b/src/main/java/com/ecosystem/todojava/exception/ChatGptSpellcheckIsNull.java
@@ -1,0 +1,7 @@
+package com.ecosystem.todojava.exception;
+
+public class ChatGptSpellcheckIsNull extends RuntimeException {
+    public ChatGptSpellcheckIsNull() {
+        super("Internal error: spell check returned null");
+    }
+}

--- a/src/main/java/com/ecosystem/todojava/exception/ChatGptSpellingRequestException.java
+++ b/src/main/java/com/ecosystem/todojava/exception/ChatGptSpellingRequestException.java
@@ -1,0 +1,7 @@
+package com.ecosystem.todojava.exception;
+
+public class ChatGptSpellingRequestException extends RuntimeException {
+    public ChatGptSpellingRequestException(String message) {
+        super("Spelling check failed: " + message);
+    }
+}

--- a/src/main/java/com/ecosystem/todojava/service/ChatGptService.java
+++ b/src/main/java/com/ecosystem/todojava/service/ChatGptService.java
@@ -1,0 +1,35 @@
+package com.ecosystem.todojava.service;
+
+import com.ecosystem.todojava.dto.ChatGptCheckTodoSpellingRequest;
+import com.ecosystem.todojava.dto.ChatGptResponse;
+import com.ecosystem.todojava.exception.ChatGptSpellingRequestException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+
+@Service
+public class ChatGptService {
+
+    private final RestClient restClient;
+
+    public ChatGptService(
+            RestClient.Builder restClientBuilder,
+            @Value("${chatgpt.api.key}") String apiKey,
+            @Value("${chatgpt.api.baseurl}") String baseUrl
+    ) {
+        this.restClient = restClientBuilder
+                .baseUrl(baseUrl)
+                .defaultHeader("Authorization", "Bearer " + apiKey)
+                .build();
+    }
+
+    public ChatGptResponse checkTodoSpelling(String todo) {
+        try {
+            ChatGptCheckTodoSpellingRequest request = new ChatGptCheckTodoSpellingRequest("gpt-4.1", todo);
+            return restClient.post().uri("").body(request).retrieve().body(ChatGptResponse.class);
+        } catch (Exception e) {
+            throw new ChatGptSpellingRequestException(e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 spring.application.name=todo-java
 spring.data.mongodb.uri=${MONGO_DB_URI}
+chatgpt.api.key=${OPENAI_API_KEY}
+chatgpt.api.baseurl=https://api.openai.com/v1/responses

--- a/src/test/java/com/ecosystem/todojava/dto/ChatGptResponseTest.java
+++ b/src/test/java/com/ecosystem/todojava/dto/ChatGptResponseTest.java
@@ -1,0 +1,66 @@
+package com.ecosystem.todojava.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChatGptResponseTest {
+    @Test
+    void chatGptResponse_getFirstOutputText_returnsText_whenPresent() {
+        ChatGptResponse.Output.Content content = new ChatGptResponse.Output.Content();
+        content.setType("text");
+        content.setText("create todo");
+
+        ChatGptResponse.Output output = new ChatGptResponse.Output();
+        output.setContent(List.of(content));
+
+        ChatGptResponse response = new ChatGptResponse();
+        response.setOutput(List.of(output));
+
+        assertEquals("create todo", response.getFirstOutputText());
+    }
+
+    @Test
+    void chatGptResponse_getFirstOutputText_returnsNull_whenOutputIsNull() {
+        ChatGptResponse response = new ChatGptResponse();
+        response.setOutput(null);
+        assertNull(response.getFirstOutputText());
+    }
+
+    @Test
+    void chatGptResponse_getFirstOutputText_returnsNull_whenOutputIsEmpty() {
+        ChatGptResponse response = new ChatGptResponse();
+        response.setOutput(List.of());
+        assertNull(response.getFirstOutputText());
+    }
+
+    @Test
+    void chatGptResponse_getFirstOutputText_returnsNull_whenContentIsNull() {
+        ChatGptResponse.Output output = new ChatGptResponse.Output();
+        output.setContent(null);
+
+        ChatGptResponse response = new ChatGptResponse();
+        response.setOutput(List.of(output));
+
+        assertNull(response.getFirstOutputText());
+    }
+
+    @Test
+    void chatGptResponse_getFirstOutputText_returnsNull_whenContentIsEmpty() {
+        ChatGptResponse.Output output = new ChatGptResponse.Output();
+        output.setContent(List.of());
+
+        ChatGptResponse response = new ChatGptResponse();
+        response.setOutput(List.of(output));
+
+        assertNull(response.getFirstOutputText());
+    }
+
+    @Test
+    void chatGptResponse_toString_includesOutput() {
+        ChatGptResponse response = new ChatGptResponse();
+        assertTrue(response.toString().contains("output="));
+    }
+}

--- a/src/test/java/com/ecosystem/todojava/exception/ChatGptSpellcheckIsNullTest.java
+++ b/src/test/java/com/ecosystem/todojava/exception/ChatGptSpellcheckIsNullTest.java
@@ -1,0 +1,19 @@
+package com.ecosystem.todojava.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChatGptSpellcheckIsNullTest {
+    @Test
+    void chatGptSpellcheckIsNull_constructor_setsCorrectMessage() {
+        ChatGptSpellcheckIsNull ex = new ChatGptSpellcheckIsNull();
+        assertEquals("Internal error: spell check returned null", ex.getMessage());
+    }
+
+    @Test
+    void chatGptSpellcheckIsNull_isInstanceOfRuntimeException() {
+        ChatGptSpellcheckIsNull ex = new ChatGptSpellcheckIsNull();
+        assertInstanceOf(RuntimeException.class, ex);
+    }
+}

--- a/src/test/java/com/ecosystem/todojava/exception/ChatGptSpellingRequestExceptionTest.java
+++ b/src/test/java/com/ecosystem/todojava/exception/ChatGptSpellingRequestExceptionTest.java
@@ -1,0 +1,20 @@
+package com.ecosystem.todojava.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChatGptSpellingRequestExceptionTest {
+    @Test
+    void chatGptSpellingRequestException_constructor_setsCorrectMessage() {
+        ChatGptSpellingRequestException ex = new ChatGptSpellingRequestException("API error");
+        assertEquals("Spelling check failed: API error", ex.getMessage());
+    }
+
+    @Test
+    void chatGptSpellingRequestException_isInstanceOfRuntimeException() {
+        ChatGptSpellingRequestException ex = new ChatGptSpellingRequestException("test");
+        assertInstanceOf(RuntimeException.class, ex);
+    }
+
+}

--- a/src/test/java/com/ecosystem/todojava/service/ChatGptServiceTest.java
+++ b/src/test/java/com/ecosystem/todojava/service/ChatGptServiceTest.java
@@ -1,0 +1,80 @@
+package com.ecosystem.todojava.service;
+
+import com.ecosystem.todojava.dto.ChatGptCheckTodoSpellingRequest;
+import com.ecosystem.todojava.dto.ChatGptResponse;
+import com.ecosystem.todojava.exception.ChatGptSpellingRequestException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.client.RestClient;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class ChatGptServiceTest {
+
+    @Mock
+    private RestClient.Builder restClientBuilder;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.RequestBodySpec requestBodySpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    private ChatGptService chatGptService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        when(restClientBuilder.baseUrl(anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.defaultHeader(anyString(), anyString())).thenReturn(restClientBuilder);
+        when(restClientBuilder.build()).thenReturn(restClient);
+
+        chatGptService = new ChatGptService(restClientBuilder, "fake-api-key", "http://fake-url");
+    }
+
+    @Test
+    void testCheckTodoSpelling_success() {
+        String todo = "Chek spelling";
+        ChatGptResponse expectedResponse = new ChatGptResponse(); // Customize as needed
+
+        when(restClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri("")).thenReturn(requestBodySpec);
+        when(requestBodySpec.body(any(ChatGptCheckTodoSpellingRequest.class))).thenReturn(requestBodySpec);
+        when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(ChatGptResponse.class)).thenReturn(expectedResponse);
+
+
+        ChatGptResponse actualResponse = chatGptService.checkTodoSpelling(todo);
+
+        assertEquals(expectedResponse, actualResponse);
+        verify(restClient).post();
+    }
+
+    @Test
+    void testCheckTodoSpelling_failure_throwsException() {
+        String todo = "Chek spelling";
+
+        when(restClient.post()).thenThrow(new RuntimeException("API error"));
+
+        ChatGptSpellingRequestException ex = assertThrows(
+                ChatGptSpellingRequestException.class,
+                () -> chatGptService.checkTodoSpelling(todo)
+        );
+
+        assertTrue(ex.getMessage().contains("API error"));
+    }
+
+
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,1 +1,3 @@
 de.flapdoodle.mongodb.embedded.version=7.0.4
+chatgpt.api.key=dummy-key
+chatgpt.api.baseurl=http://localhost


### PR DESCRIPTION
This pull request introduces a new feature that integrates OpenAI's ChatGPT API for spellchecking todo descriptions. It includes changes to implement the feature, handle exceptions, and add tests for the new functionality.

### New Feature: ChatGPT Spellcheck Integration
- Added a description of the ChatGPT spellcheck integration to the `README.md` file, explaining its purpose and usage.
- Implemented the `ChatGptService` to interact with the ChatGPT API for spellchecking todo descriptions. The service handles API calls and processes responses.
- Updated `TodoService` to use the `ChatGptService` for spellchecking todo descriptions before creating new todos.
- Added configuration properties for the ChatGPT API key and base URL in `application.properties`.

### Exception Handling
- Added `ChatGptSpellcheckIsNull` exception to handle cases where the API response is null.
- Added `ChatGptSpellingRequestException` to handle API call failures.

### Data Transfer Objects (DTOs)
- Created `ChatGptCheckTodoSpellingRequest` DTO to structure requests sent to the ChatGPT API.
- Created `ChatGptResponse` DTO to parse and process responses from the ChatGPT API.

### Testing
- Added unit tests for `ChatGptResponse` to validate response parsing logic.
- Added unit tests for `ChatGptSpellcheckIsNull` exception to ensure proper behavior.
- Updated `TodoControllerTest` to include mock server tests for the ChatGPT API integration, covering successful responses, null responses, and API failures.